### PR TITLE
Observe photo library changes

### DIFF
--- a/Tatsi/Views/Albums/AlbumsViewController.swift
+++ b/Tatsi/Views/Albums/AlbumsViewController.swift
@@ -303,7 +303,7 @@ extension AlbumsViewController {
 extension AlbumsViewController: PHPhotoLibraryChangeObserver {
     
     func photoLibraryDidChange(_ changeInstance: PHChange) {
-        guard let smartAlbumsFetchResults = smartAlbumsFetchResults, let userAlbumsFetchResults = sharedAlbumsFetchResults else {
+        guard let smartAlbumsFetchResults = smartAlbumsFetchResults, let userAlbumsFetchResults = userAlbumsFetchResults else {
             return
         }
         

--- a/Tatsi/Views/Albums/AlbumsViewController.swift
+++ b/Tatsi/Views/Albums/AlbumsViewController.swift
@@ -46,6 +46,10 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
     /// The categories of albums to display in the album list. These translate to the sections in the table view.
     fileprivate var categories: [AlbumCategory] = []
     
+    private var smartAlbumsFetchResults: PHFetchResult<PHAssetCollection>?
+    private var userAlbumsFetchResults: PHFetchResult<PHCollection>?
+    private var sharedAlbumsFetchResults: PHFetchResult<PHAssetCollection>?
+    
     lazy fileprivate var smartAlbumSortingOrder: [PHAssetCollectionSubtype] = {
         var smartAlbumSortingOrder = [
             PHAssetCollectionSubtype.smartAlbumUserLibrary,
@@ -82,6 +86,10 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
         fatalError("init(coder:) has not been implemented")
     }
     
+    deinit {
+        PHPhotoLibrary.shared().unregisterChangeObserver(self)
+    }
+    
     // MARK: - View Lifecycle
     
     override func viewDidLoad() {
@@ -104,6 +112,8 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
         self.tableView.separatorInset = UIEdgeInsets(top: 0, left: -10, bottom: 0, right: 0)
         self.tableView.separatorStyle = .none
         self.tableView.backgroundColor = self.config?.colors.background ?? TatsiConfig.default.colors.background
+        
+        PHPhotoLibrary.shared().register(self)
         
         self.tableView.accessibilityIdentifier = "tatsi.tableView.albums"
         
@@ -128,18 +138,26 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
     
     fileprivate func startLoadingAlbums() {
         var newCategories = [AlbumCategory]()
-        let smartAlbums = self.fetchSmartAlbums()
+        
+        let smartAlbumsFetchResults = PHAssetCollection.fetchAssetCollections(with: PHAssetCollectionType.smartAlbum, subtype: PHAssetCollectionSubtype.albumRegular, options: nil)
+        self.smartAlbumsFetchResults = smartAlbumsFetchResults
+        let smartAlbums = self.sortSmartAlbumResults(smartAlbumsFetchResults)
         if !smartAlbums.isEmpty {
             newCategories.append(AlbumCategory(headerTitle: nil, albums: smartAlbums))
         }
         
-        let userAlbums = self.fetchUserAlbums()
+        let userAlbumsFetchResults = PHCollectionList.fetchTopLevelUserCollections(with: nil)
+        self.userAlbumsFetchResults = userAlbumsFetchResults
+        
+        let userAlbums = self.sortUserAlbumResults(userAlbumsFetchResults)
         if !userAlbums.isEmpty {
             newCategories.append(AlbumCategory(headerTitle: LocalizableStrings.albumsViewMyAlbumsHeader, albums: userAlbums))
         }
         
         if self.config?.showSharedAlbums == true {
-            let sharedAlbums = self.fetchSharedAlbums()
+            let sharedAlbumsFetchResukts = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .albumCloudShared, options: nil)
+            self.sharedAlbumsFetchResults = sharedAlbumsFetchResukts
+            let sharedAlbums = self.sortSharedAlbumResults(sharedAlbumsFetchResukts)
             if !sharedAlbums.isEmpty {
                 newCategories.append(AlbumCategory(headerTitle: LocalizableStrings.albumsViewSharedAlbumsHeader, albums: sharedAlbums))
             }
@@ -147,8 +165,7 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
         self.categories = newCategories
     }
     
-    fileprivate func fetchSmartAlbums() -> [PHAssetCollection] {
-        let collectionResults = PHAssetCollection.fetchAssetCollections(with: PHAssetCollectionType.smartAlbum, subtype: PHAssetCollectionSubtype.albumRegular, options: nil)
+    fileprivate func sortSmartAlbumResults(_ collectionResults: PHFetchResult<PHAssetCollection>) -> [PHAssetCollection] {
         var collections = [PHAssetCollection]()
         collectionResults.enumerateObjects({ (collection, _, _) in
             guard self.config?.isCollectionAllowed(collection) == true else {
@@ -165,8 +182,7 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
         return collections
     }
     
-    fileprivate func fetchUserAlbums() -> [PHAssetCollection] {
-        let collectionResults = PHCollectionList.fetchTopLevelUserCollections(with: nil)
+    fileprivate func sortUserAlbumResults(_ collectionResults: PHFetchResult<PHCollection>) -> [PHAssetCollection] {
         var collections = [PHAssetCollection]()
         collectionResults.enumerateObjects({ (collection, _, _) in
             guard let assetCollection = collection as? PHAssetCollection, self.config?.isCollectionAllowed(collection) == true else {
@@ -183,8 +199,7 @@ final internal class AlbumsViewController: UITableViewController, PickerViewCont
         return collections
     }
     
-    fileprivate func fetchSharedAlbums() -> [PHAssetCollection] {
-        let collectionResults = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .albumCloudShared, options: nil)
+    fileprivate func sortSharedAlbumResults(_ collectionResults: PHFetchResult<PHAssetCollection>) -> [PHAssetCollection] {
         var collections = [PHAssetCollection]()
         collectionResults.enumerateObjects({ (collection, _, _) in
             collections.append(collection)
@@ -283,4 +298,33 @@ extension AlbumsViewController {
         return AlbumsTableHeaderView.height
     }
     
+}
+
+extension AlbumsViewController: PHPhotoLibraryChangeObserver {
+    
+    func photoLibraryDidChange(_ changeInstance: PHChange) {
+        guard let smartAlbumsFetchResults = smartAlbumsFetchResults, let userAlbumsFetchResults = sharedAlbumsFetchResults else {
+            return
+        }
+        
+        let smartAlbumChangeDetails = changeInstance.changeDetails(for: smartAlbumsFetchResults)
+        let userAlbumChangeDetails = changeInstance.changeDetails(for: userAlbumsFetchResults)
+    
+        var sharedAlbumChangeDetails: PHFetchResultChangeDetails<PHAssetCollection>?
+        if let sharedAlbumFetchResults = sharedAlbumsFetchResults {
+            sharedAlbumChangeDetails = changeInstance.changeDetails(for: sharedAlbumFetchResults)
+        }
+        
+        DispatchQueue.main.async {
+            guard smartAlbumChangeDetails != nil
+                || userAlbumChangeDetails != nil
+                || (self.config?.showSharedAlbums == true
+                    && sharedAlbumChangeDetails != nil) else {
+                        return
+            }
+            
+            self.startLoadingAlbums()
+            self.tableView.reloadData()
+        }
+    }
 }

--- a/Tatsi/Views/Albums/Cells/AlbumTableViewCell.swift
+++ b/Tatsi/Views/Albums/Cells/AlbumTableViewCell.swift
@@ -53,11 +53,7 @@ final internal class AlbumTableViewCell: UITableViewCell {
         return stackView
     }()
     
-    var album: PHAssetCollection? {
-        didSet {
-            self.albumChanged = self.album != oldValue || contentCount != self.album?.estimatedAssetCount
-        }
-    }
+    var album: PHAssetCollection?
 
     var colors: TatsiColors? {
         didSet {
@@ -66,9 +62,6 @@ final internal class AlbumTableViewCell: UITableViewCell {
             self.countLabel.textColor = self.colors?.secondaryLabel ?? TatsiConfig.default.colors.secondaryLabel
         }
     }
-    
-    private var albumChanged = false
-    private var contentCount = 0
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -106,12 +99,6 @@ final internal class AlbumTableViewCell: UITableViewCell {
     }
     
     func reloadContents(with options: PHFetchOptions?) {
-        guard albumChanged else {
-            return
-        }
-        
-        albumChanged = false
-        
         self.titleLabel.text = self.album?.localizedTitle
         
         let fetchOptions = options
@@ -132,7 +119,6 @@ final internal class AlbumTableViewCell: UITableViewCell {
                 return
             }
             
-            self?.contentCount = count
             self?.countLabel.text = AlbumTableViewCell.numberFormatter.string(from: NSNumber(value: count))
             self?.accessibilityValue = String(format: LocalizableStrings.accessibilityAlbumImagesCount, locale: nil, arguments: [count])
         })

--- a/Tatsi/Views/Albums/Cells/AlbumTableViewCell.swift
+++ b/Tatsi/Views/Albums/Cells/AlbumTableViewCell.swift
@@ -55,7 +55,7 @@ final internal class AlbumTableViewCell: UITableViewCell {
     
     var album: PHAssetCollection? {
         didSet {
-            self.albumChanged = self.album != oldValue
+            self.albumChanged = self.album != oldValue || contentCount != self.album?.estimatedAssetCount
         }
     }
 
@@ -68,6 +68,7 @@ final internal class AlbumTableViewCell: UITableViewCell {
     }
     
     private var albumChanged = false
+    private var contentCount = 0
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -99,17 +100,17 @@ final internal class AlbumTableViewCell: UITableViewCell {
             self.labelsStackView.centerYAnchor.constraint(equalTo: self.albumImageView.centerYAnchor),
             self.labelsStackView.leadingAnchor.constraint(equalTo: self.albumImageView.trailingAnchor, constant: 16),
             self.layoutMarginsGuide.trailingAnchor.constraint(greaterThanOrEqualTo: self.labelsStackView.trailingAnchor)
-            
         ]
         
         NSLayoutConstraint.activate(constraints)
     }
     
     func reloadContents(with options: PHFetchOptions?) {
-        guard self.albumChanged else {
+        guard albumChanged else {
             return
         }
-        self.albumChanged = false
+        
+        albumChanged = false
         
         self.titleLabel.text = self.album?.localizedTitle
         
@@ -130,6 +131,8 @@ final internal class AlbumTableViewCell: UITableViewCell {
             guard let strongSelf = self, collection == strongSelf.album else {
                 return
             }
+            
+            self?.contentCount = count
             self?.countLabel.text = AlbumTableViewCell.numberFormatter.string(from: NSNumber(value: count))
             self?.accessibilityValue = String(format: LocalizableStrings.accessibilityAlbumImagesCount, locale: nil, arguments: [count])
         })


### PR DESCRIPTION
This prevents an issue in apps that run on iOS 14 that were built against the iOS 13 SDK. The new limited photo library feature affects all apps using PhotoKit, including the ones that were built for previous iOS versions. Because those apps can't customize the experience the system prompts users with the question of whether they want to update their limited photo library selection, the first time the app accesses any PhotoKit API's. Currently, if a user updates that selection it is not reflected in the `Tatsi` photo picker UI. This PR fixes that by reacting to photo library changes in the `AssetGrindViewController` and `AlbumsViewController`.
